### PR TITLE
Corrected public URL of repository on docker hub and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ This Docker image should be used in conjunction with the
 ## Usage
 
 The docker images are available on 
-[Glue Software Engineering AG - MessageHandler Images](https://hub.docker.com/repository/docker/gluech/msghandler/)
+[Glue Software Engineering AG - MessageHandler Images](https://hub.docker.com/r/gluech/msghandler)
 
 To use the MessageHandler images from Docker hub, run
 
 ```
-docker pull gluech/msghandler:1.0.0
+docker pull gluech/msghandler:mh-1.0.0
 ```
 
 ## How to test drive MH?


### PR DESCRIPTION
First release with MessageHandler 3.4.2, Amazon Corretto JRE 8u372, Alpine 3.17